### PR TITLE
Metrics for depth+ebv limited analyses

### DIFF
--- a/mafContrib/lssmetrics/__init__.py
+++ b/mafContrib/lssmetrics/__init__.py
@@ -1,0 +1,3 @@
+__all__= [
+        'egFootprintMetric'
+]

--- a/mafContrib/lssmetrics/__init__.py
+++ b/mafContrib/lssmetrics/__init__.py
@@ -1,3 +1,4 @@
 __all__= [
-        'egFootprintMetric'
+        'egFootprintMetric',
+        'depthLimitedNumGalMetric'
 ]

--- a/mafContrib/lssmetrics/depthLimitedNumGalMetric.py
+++ b/mafContrib/lssmetrics/depthLimitedNumGalMetric.py
@@ -34,9 +34,14 @@ class depthLimitedNumGalMetric(metrics.BaseMetric):
         self.m5Col = m5Col
         self.filterCol = filterCol
         self.filterBand = filterBand
+        # set up the extended source limiting mag
+        # galaxies are x2 as seeing: seeing is generally 0.7arcsec and a typical galaxies is 1arcsec
+        # => for extended source limiting mag of x, we'd need x + 0.7 as the point-source limiting mag; 0.7 comes from
+        # $\sqrt{1/2}$; basically have x2 difference in magnitudes between point source and extended source.
+        lim_mag_i_extsrc = lim_mag_i_ptsrc - 0.7
         # set up the metric for galaxy counts
         self.galmetric = GalaxyCountsMetric(m5Col=self.m5Col, nside=nside,
-                                            upperMagLimit=32.0,
+                                            upperMagLimit=lim_mag_i_extsrc,
                                             includeDustExtinction=True,
                                             filterBand=self.filterBand, redshiftBin=redshiftBin,
                                             CFHTLSCounts=False,

--- a/mafContrib/lssmetrics/depthLimitedNumGalMetric.py
+++ b/mafContrib/lssmetrics/depthLimitedNumGalMetric.py
@@ -1,0 +1,64 @@
+import lsst.sims.maf.metrics as metrics
+import numpy as np
+from mafContrib.LSSObsStrategy.galaxyCountsMetric_extended import GalaxyCountsMetric_extended as GalaxyCountsMetric
+from mafContrib.lssmetrics.egFootprintMetric import egFootprintMetric
+
+class depthLimitedNumGalMetric(metrics.BaseMetric):
+    """
+
+    This metric calculates the number of galaxies while accounting for the extragalactic footprint.
+
+    Parameters
+    ----------
+        * m5Col: str: name of column for depth in the data. Default: 'fiveSigmaDepth'
+        * filterCol: str: name of column for filter in the data. Default: 'filter'
+        * maps: arr: array of map names. Default: ['DustMap']
+        * nside: int: HEALpix resolution parameter. Default: 256
+        * filterBand: str: any one of 'u', 'g', 'r', 'i', 'z', 'y'. Default: 'i'
+        * redshiftBin: str: options include '0.<z<0.15', '0.15<z<0.37', '0.37<z<0.66, '0.66<z<1.0',
+                            '1.0<z<1.5', '1.5<z<2.0', '2.0<z<2.5', '2.5<z<3.0','3.0<z<3.5', '3.5<z<4.0',
+                            'all' for no redshift restriction (so consider 0.<z<4.0)
+                            Default: 'all'
+        * nfilters_needed: int: number of filters in which to require coverage. Default: 6
+        * lim_mag_i: float: limiting mag for the i-band coadded dust-corrected depth. Default: 26.0
+        * lim_ebv: float: limiting EBV value. Default: 0.2
+
+    Returns
+    -------
+        * 1 if the slicePoint passes the extragalactic cuts; otherwise self.badval
+
+    """
+    def __init__(self, m5Col='fiveSigmaDepth', filterCol='filter',
+                 maps=['DustMap'], nside=128, filterBand='i', redshiftBin='all',
+                 nfilters_needed=6, lim_mag_i=26.0, lim_ebv=0.2, **kwargs):
+        self.m5Col = m5Col
+        self.filterCol = filterCol
+        self.filterBand = filterBand
+        # set up the metric for galaxy counts
+        self.galmetric = GalaxyCountsMetric(m5Col=self.m5Col, nside=nside,
+                                            upperMagLimit=32.0,
+                                            includeDustExtinction=True,
+                                            filterBand=self.filterBand, redshiftBin=redshiftBin,
+                                            CFHTLSCounts=False,
+                                            normalizedMockCatalogCounts=True,
+                                            maps=maps)
+        # set up the metric for extragalactic footprint
+        self.eg_metric = egFootprintMetric(m5Col=self.m5Col, filterCol=self.filterCol, maps=maps,
+                                           nfilters_needed=nfilters_needed,
+                                           lim_mag_i=lim_mag_i, lim_ebv=lim_ebv, return_coadd_band=None)
+        # insantiate the parent object
+        super(depthLimitedNumGalMetric, self).__init__(col=[self.m5Col, self.filterCol],
+                                                       maps=maps, **kwargs)
+        self.metricDtype = 'object'
+
+    def run(self, dataslice, slicePoint=None):
+        # see if this slicePoint is in the extragalactic footprint
+        pass_egcuts = self.eg_metric.run(dataslice,
+                                         slicePoint=slicePoint)
+        if pass_egcuts == 1:
+            # find the galaxy counts
+            in_filt = np.where(dataslice[self.filterCol] == self.filterBand)[0]
+            return self.galmetric.run(dataslice[in_filt],
+                                      slicePoint=slicePoint)
+        else:
+            return self.badval

--- a/mafContrib/lssmetrics/depthLimitedNumGalMetric.py
+++ b/mafContrib/lssmetrics/depthLimitedNumGalMetric.py
@@ -20,7 +20,7 @@ class depthLimitedNumGalMetric(metrics.BaseMetric):
                             'all' for no redshift restriction (so consider 0.<z<4.0)
                             Default: 'all'
         * nfilters_needed: int: number of filters in which to require coverage. Default: 6
-        * lim_mag_i: float: limiting mag for the i-band coadded dust-corrected depth. Default: 26.0
+        * lim_mag_i_ptsrc: float: point-source limiting mag for the i-band coadded dust-corrected depth. Default: 26.0
         * lim_ebv: float: limiting EBV value. Default: 0.2
 
     Returns
@@ -30,7 +30,7 @@ class depthLimitedNumGalMetric(metrics.BaseMetric):
     """
     def __init__(self, m5Col='fiveSigmaDepth', filterCol='filter',
                  maps=['DustMap'], nside=128, filterBand='i', redshiftBin='all',
-                 nfilters_needed=6, lim_mag_i=26.0, lim_ebv=0.2, **kwargs):
+                 nfilters_needed=6, lim_mag_i_ptsrc=26.0, lim_ebv=0.2, **kwargs):
         self.m5Col = m5Col
         self.filterCol = filterCol
         self.filterBand = filterBand
@@ -45,7 +45,7 @@ class depthLimitedNumGalMetric(metrics.BaseMetric):
         # set up the metric for extragalactic footprint
         self.eg_metric = egFootprintMetric(m5Col=self.m5Col, filterCol=self.filterCol, maps=maps,
                                            nfilters_needed=nfilters_needed,
-                                           lim_mag_i=lim_mag_i, lim_ebv=lim_ebv, return_coadd_band=None)
+                                           lim_mag_i_ptsrc=lim_mag_i_ptsrc, lim_ebv=lim_ebv, return_coadd_band=None)
         # insantiate the parent object
         super(depthLimitedNumGalMetric, self).__init__(col=[self.m5Col, self.filterCol],
                                                        maps=maps, **kwargs)

--- a/mafContrib/lssmetrics/egFootprintMetric.py
+++ b/mafContrib/lssmetrics/egFootprintMetric.py
@@ -1,0 +1,93 @@
+#######################################################################################################################
+# This metric masks any pixels that do not pass depth and extinction cuts needed for extragalactic science. There is
+# also an option to return the dust-corrected coadded depth for a specified band; otherwise a mask is returned (with
+# only the pixels in the extragalactic are unmasked and are assigned a value of 1.)
+#
+# Humna Awan: humna.awan@rutgers.edu
+#
+#######################################################################################################################
+import lsst.sims.maf.metrics as metrics
+import numpy as np
+
+class egFootprintMetric(metrics.BaseMetric):
+    """
+
+    This metric determines whether input slicePoint is in the extragalactic footprint (i.e.,
+    has coverage in all 6 filters and passes both a depth and an EBV cut, e.g. for Y10, need
+    i > 26.0 and ebv < 0.2).
+
+    Parameters
+    ----------
+        * m5Col: str: name of column for depth in the data. Default: 'fiveSigmaDepth'
+        * filterCol: str: name of column for filter in the data. Default: 'filter'
+        * maps: arr: array of map names. Default: ['DustMap']
+        * nfilters_needed: int: number of filters in which to require coverage. Default: 6
+        * lim_mag_i: float: limiting mag for the i-band coadded dust-corrected depth. Default: 26.0
+        * lim_ebv: float: limiting EBV value. Default: 0.2
+        * return_coadd_band: None or one of 'u', 'g', 'r', 'i', 'z', 'y'. Use to specify whether
+                             want coadded depth value returned for the good pixels. Default: None.
+
+    Returns
+    -------
+        if return_coadd_band is specified:
+            * coadded depth in the specified band if the slicePoint passes the extragalactic cuts; otherwise self.badval
+        else:
+            * 1 if the slicePoint passes the extragalactic cuts; otherwise self.badval
+
+    """
+    def __init__(self, m5Col='fiveSigmaDepth',  filterCol='filter', maps=['DustMap'],
+                 nfilters_needed=6, lim_mag_i=26.0, lim_ebv=0.2, return_coadd_band=None, **kwargs):
+        self.m5Col = m5Col
+        self.filterCol = filterCol
+        self.nfilters_needed = int(nfilters_needed)
+        self.lim_mag_i = lim_mag_i
+        self.lim_ebv = lim_ebv
+        self.filters = ['u', 'g', 'r', 'i', 'z', 'y']
+        if (return_coadd_band is not None) and (return_coadd_band not in self.filters):
+            raise ValueError('return_coadd_band must be one of the bands if not None: %s' % return_coadd_band)
+        self.return_coadd_band = return_coadd_band
+        if self.return_coadd_band is None:
+            self.return_coadd = False
+        else:
+            self.return_coadd = True
+
+        self.coadd_with_dust = {}
+        for band in self.filters:
+            self.coadd_with_dust[band] = metrics.ExgalM5(lsstFilter=band, 
+                                                         m5Col=self.m5Col,)
+
+        # insantiate the parent object
+        super(egFootprintMetric, self).__init__(col=[self.m5Col, self.filterCol],
+                                                maps=maps, **kwargs)
+        self.metricDtype = 'object'
+
+    def run(self, dataslice, slicePoint=None):
+        nfilters = 0
+        # see which filters are covered
+        for band in self.filters:
+            in_filt = np.where(dataslice[self.filterCol] == band)[0]
+            coadd = self.coadd_with_dust[band].run(dataslice[in_filt],
+                                                       slicePoint={'ebv': slicePoint['ebv']})
+            if coadd > 0: nfilters += 1
+            if band == 'i': ext_iband_coadd = coadd
+            if self.return_coadd and (self.return_coadd_band == band):
+                to_return = coadd
+
+        # figure out the conditions with the number of filters in which we want coverage
+        keep_condition = (nfilters == self.nfilters_needed)
+
+        # get ebv
+        ebv = slicePoint['ebv']
+
+        # now incorporate depth + ebv cuts
+        keep_condition = keep_condition and (ebv < self.lim_ebv) and (ext_iband_coadd > self.lim_mag_i)
+
+        # mask the slice pt if keep_condition is false
+        if keep_condition:
+            if self.return_coadd:
+                return to_return
+            else:
+                return 1
+        else:
+            # return a single badval which will mask the datapoint in the bundle.metricValues.
+            return self.badval

--- a/mafContrib/lssmetrics/egFootprintMetric.py
+++ b/mafContrib/lssmetrics/egFootprintMetric.py
@@ -22,7 +22,7 @@ class egFootprintMetric(metrics.BaseMetric):
         * filterCol: str: name of column for filter in the data. Default: 'filter'
         * maps: arr: array of map names. Default: ['DustMap']
         * nfilters_needed: int: number of filters in which to require coverage. Default: 6
-        * lim_mag_i: float: limiting mag for the i-band coadded dust-corrected depth. Default: 26.0
+        * lim_mag_i_ptsrc: float: point-source limiting mag for the i-band coadded dust-corrected depth. Default: 26.0
         * lim_ebv: float: limiting EBV value. Default: 0.2
         * return_coadd_band: None or one of 'u', 'g', 'r', 'i', 'z', 'y'. Use to specify whether
                              want coadded depth value returned for the good pixels. Default: None.
@@ -36,11 +36,11 @@ class egFootprintMetric(metrics.BaseMetric):
 
     """
     def __init__(self, m5Col='fiveSigmaDepth',  filterCol='filter', maps=['DustMap'],
-                 nfilters_needed=6, lim_mag_i=26.0, lim_ebv=0.2, return_coadd_band=None, **kwargs):
+                 nfilters_needed=6, lim_mag_i_ptsrc=26.0, lim_ebv=0.2, return_coadd_band=None, **kwargs):
         self.m5Col = m5Col
         self.filterCol = filterCol
         self.nfilters_needed = int(nfilters_needed)
-        self.lim_mag_i = lim_mag_i
+        self.lim_mag_i_ptsrc = lim_mag_i_ptsrc
         self.lim_ebv = lim_ebv
         self.filters = ['u', 'g', 'r', 'i', 'z', 'y']
         if (return_coadd_band is not None) and (return_coadd_band not in self.filters):
@@ -80,7 +80,7 @@ class egFootprintMetric(metrics.BaseMetric):
         ebv = slicePoint['ebv']
 
         # now incorporate depth + ebv cuts
-        keep_condition = keep_condition and (ebv < self.lim_ebv) and (ext_iband_coadd > self.lim_mag_i)
+        keep_condition = keep_condition and (ebv < self.lim_ebv) and (ext_iband_coadd > self.lim_mag_i_ptsrc)
 
         # mask the slice pt if keep_condition is false
         if keep_condition:


### PR DESCRIPTION
Here is a metric (`egFootprintMetric`) that implements a depth+ebv cut, needed for high S/N analysis for DESC static science.

Also included is an extension (`depthLimitedNumGalMetric`) of a previous metric (`LSSObsStrategy/GalaxyCountsMetric_extended`) that accounts for the depth+ebv cut when estimating the number of galaxies at a given redshift; note that this metric is not super relevant for DESC-LSS science (since we are way past the shot noise limit) but may be of interest for other science.